### PR TITLE
Feature: Sort launches by date

### DIFF
--- a/src/components/LaunchDataPage.jsx
+++ b/src/components/LaunchDataPage.jsx
@@ -1,3 +1,8 @@
+import { useState } from "react";
+import { Button as MaterialButton } from "@mui/material";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+
 import { Error } from "./Error";
 import { TableSkeleton } from "./Skeleton";
 import CardGallery from "./card/CardGallery";
@@ -6,13 +11,23 @@ import { SearchBox } from "./SearchBox";
 
 import { useData } from "../hooks/useData";
 import { usePagination } from "../hooks/usePagination";
+import { sortByTimestamp } from "../utils/sortData";
 
 import "./LaunchDataPage.css";
 
-export const LaunchDataPage = () => {
+const LaunchDataPage = () => {
   const { data, loading, error, searchByName } = useData(
     "https://api.spacexdata.com/v4/launches"
   );
+
+  const [sortOrder, setSortOrder] = useState("ascending");
+
+  const toggleSortOrder = () => {
+    const newSortOrder = sortOrder === "ascending" ? "descending" : "ascending";
+    setSortOrder(newSortOrder);
+  };
+
+  const sortedData = sortByTimestamp(data, sortOrder);
 
   const perPage = 5;
   const {
@@ -23,13 +38,13 @@ export const LaunchDataPage = () => {
     canGetPrevious,
     getNext,
     getPrevious,
-  } = usePagination(data, perPage);
+  } = usePagination(sortedData, perPage);
 
-  //API returned no results state?
-  //Calling hook for both Card and Table, can put in one page component?
   if (loading) return <TableSkeleton />;
   if (error) return <Error />;
-  if (!data || !paginatedData) return <div>No data</div>;
+
+  const foundData = paginatedData && paginatedData.length;
+
   return (
     <>
       <h1>SpaceX Launches</h1>
@@ -38,9 +53,25 @@ export const LaunchDataPage = () => {
         ariaLabel="Search for SpaceX Launches by name"
         handlerFunction={searchByName}
       />
-      <CardGallery data={paginatedData} />
+      {foundData && (
+        <div>
+          <MaterialButton variant="text" onClick={toggleSortOrder}>
+            {sortOrder === "ascending" ? (
+              <KeyboardArrowUpIcon />
+            ) : (
+              <KeyboardArrowDownIcon />
+            )}
+            Sort date
+          </MaterialButton>
+        </div>
+      )}
       {/* Note: Should restrict card gallery size as buttons bounce around page onClick and scroll is necessary ATM*/}
       {/* BUG: After filtration, restore currentPage to 1 */}
+      {foundData ? (
+        <CardGallery data={paginatedData} />
+      ) : (
+        <div>No launch data found</div>
+      )}
       <Button
         disabled={!canGetPrevious}
         onClick={getPrevious}

--- a/src/utils/sortData.js
+++ b/src/utils/sortData.js
@@ -1,0 +1,15 @@
+export const sortByTimestamp = (data, order = "ascending") => {
+  if (!data || !data.length) return;
+  try {
+    const sorted = data?.sort((a, b) => {
+      const dateA = new Date(a.date_local);
+      const dateB = new Date(b.date_local);
+      if (order === "ascending") return dateA - dateB;
+      return dateB - dateA;
+    });
+    return sorted;
+  } catch (e) {
+    console.log(`An error occurred while sorting data in ${order} order: ${e}`);
+    return;
+  }
+};


### PR DESCRIPTION
**Details** 

- As per requirements, introduced functionality to sort launches **by date**, since it's historical data.
- In the future, we could consider allowing users to sort by name too.
- By **default**, the data is sorted in **ascending** order (as there's a lot of data missing for more recent launches e.g. image, description etc). 
- However, it makes sense to **change this to show most recent data by default** (descending order) in the future. 
- Design improvements will follow in another PR.

**Ascending order (default):**
![Screenshot 2024-06-23 at 17 16 53](https://github.com/guodap/space-mission-portal/assets/33546350/a1ac1ab7-08cd-472d-a20e-ea143ac7ca00)

**Descending order (on click):**
![Screenshot 2024-06-23 at 17 17 03](https://github.com/guodap/space-mission-portal/assets/33546350/bd0bab6f-38a4-46fa-85f0-4286aebefb0d)

